### PR TITLE
when deleting multiple messages, will delete the correct set

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -22,14 +22,17 @@ Hooks.once("ready", async function () {
         "depruner-chat-message-remover",
         "limit"
       );
-      const messagesToDelete = game.messages.contents.length - maxMessages;
-      if (messagesToDelete <= 0) return;
-      for (let i = 0; i <= messagesToDelete; i++) {
-        const oldestMessage = game.messages.contents[i];
-        if (oldestMessage) {
-          await oldestMessage?.delete();
-        }
-      }
+      
+      const deleteCount = game.messages.contents.length - maxMessages;
+      if (deleteCount <= 0) return;
+
+      const messagesToDelete = [...game.messages.contents.slice(0, deleteCount)];
+      
+      await Promise.all(
+        messagesToDelete.map((message) => {
+          return message.delete();
+        })
+      );
     }
   );
 });


### PR DESCRIPTION
Without this fix, the code being called to delete multiple messages (e.g., when first enabled, or after a limit reduction) would delete the wrong set of messages, because calling `message.delete()` removes the message from the `game.messages` set (though, not necessarily before the promise resolves – this is why I couldn't just change it to delete `messagesToDelete[0]`)